### PR TITLE
Switch Moshi dependency from moshi-kotlin to moshi

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -70,7 +70,7 @@ ext.libs = [
     stetho: "com.facebook.stetho:stetho:$versions.stetho",
     stethoOkHttp: "com.facebook.stetho:stetho-okhttp3:$versions.stethoOkHttp",
 
-    moshi: "com.squareup.moshi:moshi-kotlin:$versions.moshi",
+    moshi: "com.squareup.moshi:moshi:$versions.moshi",
     moshiCodeGen: "com.squareup.moshi:moshi-kotlin-codegen:$versions.moshi",
     gson: "com.google.code.gson:gson:$versions.gson",
     protobuf: "com.google.protobuf:protobuf-java:$versions.protobuf",


### PR DESCRIPTION
This PR fixes issue #196 by switching the Moshi dependency from `moshi-kotlin` to the standard `moshi` library.

## Changes
- Updated `dependencies.gradle` to use `com.squareup.moshi:moshi` instead of `com.squareup.moshi:moshi-kotlin`

## Benefits
- Removes the kotlin-reflect dependency (2.5MB jar file)
- Reduces final app size
- Maintains full compatibility since MoshiMessageAdapter doesn't use Kotlin-specific features
- Aligns with Retrofit's approach which also uses the standard moshi library

## Testing
The existing test suite should continue to pass as the MoshiMessageAdapter implementation doesn't rely on any Kotlin-specific Moshi features. The test files continue to use kotlin-reflect as a test dependency which is appropriate.

Closes Tinder/Scarlet#196